### PR TITLE
Adding Twitter Link Preview Card 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Svelte SEO is a plugin that makes managing your SEO easier in Svelte projects.
   - [Open Graph](#open-graph)
     - [Basic Example](#basic-example)
     - [Article Example](#article-example)
+  - [Twitter Link Preview Card](#twitter-link-preview-card)
 - [Acknowledgements](#acknowledgements)
 - [License](#license)
 
@@ -67,6 +68,11 @@ Import Svelte SEO and add the desired properties. This will render out the tags 
 | `openGraph.article.authors`        | string[]                | Writers of the article.                                                                                                                         |
 | `openGraph.article.section`        | string                  | A high-level section name. E.g. Technology                                                                                                      |
 | `openGraph.article.tags`           | string[]                | Tag words associated with this article.                                                                                                         |
+| `twitterCard.site`                 | string                  | The Twitter @username the card should be attributed to. |
+| `twitterCard.title`                | string                  | A concise title for the related content. Note- iOS, Android: Truncated to two lines in timeline and expanded Tweet ; Web: Truncated to one line in timeline and expanded Tweet |
+| `twitterCard.description`          | string                  | A description that concisely summarizes the content as appropriate for presentation within a Tweet. You should not re-use the title as the description or use this field to describe the general services provided by the website. Note- iOS, Android: Not displayed ; Web: Truncated to three lines in timeline and expanded Tweet |
+| `twitterCard.image`                | string(url)             | A URL to a unique image representing the content of the page. Images for this Card support an aspect ratio of 2:1 with minimum dimensions of 300x157 or maximum of 4096x4096 pixels. Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported. |
+|`twitterCard.imageAlt`              | string                  | A text description of the image conveying the essential nature of an image to users who are visually impaired. Maximum 420 characters. |
 
 ### Open Graph
 
@@ -134,6 +140,28 @@ Svelte SEO currently supports:
         alt: "Og Image Alt",
       },
     ],
+  }}
+/>
+```
+
+### Twitter Link Preview Card
+
+Allows Twitter Link Preview Cards (otherwise known as a Summary Card with Large Image) to be rendered. For more info check [here](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image)
+
+#### Twitter Example
+
+```svelte
+<script>
+  import SvelteSeo from "svelte-seo";
+</script>
+
+<SvelteSeo
+  twitterCard={{
+    site: "@username",
+    title: "Twitter Card Title",
+    description: "Description of Twitter Card",
+    image: "https://www.example.com/images/cover.jpg",
+    imageAlt: "Alt text for the card!",
   }}
 />
 ```

--- a/src/SvelteSeo.svelte
+++ b/src/SvelteSeo.svelte
@@ -6,6 +6,7 @@
   export let keywords = undefined;
   export let canonical = undefined;
   export let openGraph = undefined;
+  export let twitterCard = undefined;
 </script>
 
 <svelte:head>
@@ -94,6 +95,40 @@
           <meta property="og:image:height" content={image.height.toString()} />
         {/if}
       {/each}
+    {/if}
+  {/if}
+  
+  {#if twitterCard}
+    <meta name="twitter:card" content="summary_large_image">
+    {#if twitterCard.site}
+      <meta 
+        name="twitter:site" 
+        content={twitterCard.site}
+      >
+    {/if}
+    {#if twitterCard.title}
+      <meta 
+        name="twitter:title" 
+        content={twitterCard.title}
+      >
+    {/if}
+    {#if twitterCard.description}
+      <meta 
+        name="twitter:description" 
+        content={twitterCard.description}
+      >
+    {/if}
+    {#if twitterCard.image}
+      <meta 
+        name="twitter:image" 
+        content={twitterCard.image}
+      >
+    {/if}
+    {#if twitterCard.imageAlt}
+      <meta 
+        name="twitter:image:alt" 
+        content={twitterCard.imageAlt}
+      >
     {/if}
   {/if}
 </svelte:head>

--- a/src/SvelteSeo.svelte
+++ b/src/SvelteSeo.svelte
@@ -99,36 +99,36 @@
   {/if}
   
   {#if twitterCard}
-    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:card" content="summary_large_image" />
     {#if twitterCard.site}
       <meta 
         name="twitter:site" 
         content={twitterCard.site}
-      >
+      />
     {/if}
     {#if twitterCard.title}
       <meta 
         name="twitter:title" 
         content={twitterCard.title}
-      >
+      />
     {/if}
     {#if twitterCard.description}
       <meta 
         name="twitter:description" 
         content={twitterCard.description}
-      >
+      />
     {/if}
     {#if twitterCard.image}
       <meta 
         name="twitter:image" 
         content={twitterCard.image}
-      >
+      />
     {/if}
     {#if twitterCard.imageAlt}
       <meta 
         name="twitter:image:alt" 
         content={twitterCard.imageAlt}
-      >
+      />
     {/if}
   {/if}
 </svelte:head>


### PR DESCRIPTION
This PR adds the ability to pass an object to a twitterCard prop on the `<SvelteSeo />` component. These Twitter link preview cards require custom meta tags unlike Google & Facebook. This solves that problem. I also updated the README to reflect the changes. Thanks for making this!