### PR TITLE
Added Twitter summary and card types, typed and tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ Import Svelte SEO and add the desired properties. This will render out the tags 
 
 ```svelte
 <script>
+  import SvelteSeo from "svelte-seo";
 </script>
 
 <SvelteSeo
   title="Simple Usage Example"
-  description="A short description goes here." />
+  description="A short description goes here."
+/>
 ```
 
 ### Svelte SEO options
@@ -75,15 +77,15 @@ Import Svelte SEO and add the desired properties. This will render out the tags 
 | `openGraph.article.authors`        | string[]                | Writers of the article.                                                                                                                                                                                                                                                                                                                              |
 | `openGraph.article.section`        | string                  | A high-level section name. E.g. Technology                                                                                                                                                                                                                                                                                                           |
 | `openGraph.article.tags`           | string[]                | Tag words associated with this article.                                                                                                                                                                                                                                                                                                              |
-| `twitter.card`                     | string                  | Card type (one of `summary`, `summary_large_image`, `player`), defaults to `summary_large_image`                                                                                                                                                                                                                                                     |
+| `twitter.card`                     | string                  | Card type (one of `summary`, `summary_large_image`, `player`), defaults to `summary_large_image`       |
 | `twitter.site`                     | string                  | The Twitter @username the card should be attributed to.                                                                                                                                                                                                                                                                                              |
 | `twitter.title`                    | string                  | A concise title for the related content. Note- iOS, Android: Truncated to two lines in timeline and expanded Tweet ; Web: Truncated to one line in timeline and expanded Tweet                                                                                                                                                                       |
 | `twitter.description`              | string                  | A description that concisely summarizes the content as appropriate for presentation within a Tweet. You should not re-use the title as the description or use this field to describe the general services provided by the website. Note- iOS, Android: Not displayed ; Web: Truncated to three lines in timeline and expanded Tweet                  |
 | `twitter.image`                    | string(url)             | A URL to a unique image representing the content of the page. Images for this Card support an aspect ratio of 2:1 with minimum dimensions of 300x157 or maximum of 4096x4096 pixels. Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported. |
 | `twitter.imageAlt`                 | string                  | A text description of the image conveying the essential nature of an image to users who are visually impaired. Maximum 420 characters.                                                                                                                                                                                                               |
-| `twitter.player`                   | string                  | Url for the video to play in the card. Only used with the `player` type card.                                                                                                                                                                                                                                                                        |
-| `twitter.playerWidth`              | number                  | Width of the player that plays the content on twitter (in Pixels). Only used with the `player` type card.                                                                                                                                                                                                                                            |
-| `twitter.playerHeight`             | number                  | Height of the player that plays the content on twtter (in Pixels). ONly used with the `player` type card.                                                                                                                                                                                                                                            |
+| `twitter.player`                   | string                  | Url for the video to play in the card. Only used with the `player` type card.  |
+| `twitter.playerWidth`              | number                  | Width of the player that plays the content on twitter (in Pixels). Only used with the `player` type card.  |
+| `twitter.playerHeight`             | number                  | Height of the player that plays the content on twtter (in Pixels). ONly used with the `player` type card.    |    
 | `jsonLd`                           | object                  | Data in `ld+json` format. [See Examples](#json-dl-example).                                                                                                                                                                                                                                                                                          |
 
 ### Open Graph
@@ -99,10 +101,13 @@ Svelte SEO currently supports:
 
 ```svelte
 <script>
+  import SvelteSeo from "svelte-seo";
 </script>
 
 <SvelteSeo
-  openGraph={  description: 'Open Graph Description',
+  openGraph={{
+    title: 'Open Graph Title',
+    description: 'Open Graph Description',
     url: 'https://www.example.com/page',
     type: 'website',
     images: [
@@ -114,17 +119,19 @@ Svelte SEO currently supports:
       }
      ]
   }}
-/>} />
+/>
 ```
 
 #### Article Example
 
 ```svelte
 <script>
+  import SvelteSeo from "svelte-seo";
 </script>
 
 <SvelteSeo
-  openGraph={tle",
+  openGraph={{
+    title: "Open Graph Article Title",
     description: "Description of open graph article",
     type: "article",
     url: "https://www.example.com/articles/article-title",
@@ -148,7 +155,7 @@ Svelte SEO currently supports:
       },
     ],
   }}
-/>} />
+/>
 ```
 
 ### Twitter Link Preview Card
@@ -159,15 +166,18 @@ Allows Twitter Link Preview Cards (otherwise known as a Summary Card with Large 
 
 ```svelte
 <script>
+  import SvelteSeo from "svelte-seo";
 </script>
 
 <SvelteSeo
-  twitter={ "Twitter Card Title",
+  twitter={{
+    site: "@username",
+    title: "Twitter Card Title",
     description: "Description of Twitter Card",
     image: "https://www.example.com/images/cover.jpg",
     imageAlt: "Alt text for the card!",
   }}
-/>} />
+/>
 ```
 
 ### JSON-LD
@@ -180,10 +190,13 @@ To discover all the different content types JSON-LD offers check out: https://de
 
 ```svelte
 <script>
+  import SvelteSeo from "svelte-seo";
 </script>
 
 <SvelteSeo
-  jsonLd={ntityOfPage: {
+  jsonLd={{
+    '@type': 'Article',
+    mainEntityOfPage: {
       '@type': 'WebPage',
       '@id': 'https://example.com/article'
     },
@@ -208,7 +221,7 @@ To discover all the different content types JSON-LD offers check out: https://de
       }
     }
   }}
-/>} />
+/>
 ```
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -47,13 +47,11 @@ Import Svelte SEO and add the desired properties. This will render out the tags 
 
 ```svelte
 <script>
-  import SvelteSeo from "svelte-seo";
 </script>
 
 <SvelteSeo
   title="Simple Usage Example"
-  description="A short description goes here."
-/>
+  description="A short description goes here." />
 ```
 
 ### Svelte SEO options
@@ -77,11 +75,15 @@ Import Svelte SEO and add the desired properties. This will render out the tags 
 | `openGraph.article.authors`        | string[]                | Writers of the article.                                                                                                                                                                                                                                                                                                                              |
 | `openGraph.article.section`        | string                  | A high-level section name. E.g. Technology                                                                                                                                                                                                                                                                                                           |
 | `openGraph.article.tags`           | string[]                | Tag words associated with this article.                                                                                                                                                                                                                                                                                                              |
+| `twitter.card`                     | string                  | Card type (one of `summary`, `summary_large_image`, `player`), defaults to `summary_large_image`                                                                                                                                                                                                                                                     |
 | `twitter.site`                     | string                  | The Twitter @username the card should be attributed to.                                                                                                                                                                                                                                                                                              |
 | `twitter.title`                    | string                  | A concise title for the related content. Note- iOS, Android: Truncated to two lines in timeline and expanded Tweet ; Web: Truncated to one line in timeline and expanded Tweet                                                                                                                                                                       |
 | `twitter.description`              | string                  | A description that concisely summarizes the content as appropriate for presentation within a Tweet. You should not re-use the title as the description or use this field to describe the general services provided by the website. Note- iOS, Android: Not displayed ; Web: Truncated to three lines in timeline and expanded Tweet                  |
 | `twitter.image`                    | string(url)             | A URL to a unique image representing the content of the page. Images for this Card support an aspect ratio of 2:1 with minimum dimensions of 300x157 or maximum of 4096x4096 pixels. Images must be less than 5MB in size. JPG, PNG, WEBP and GIF formats are supported. Only the first frame of an animated GIF will be used. SVG is not supported. |
 | `twitter.imageAlt`                 | string                  | A text description of the image conveying the essential nature of an image to users who are visually impaired. Maximum 420 characters.                                                                                                                                                                                                               |
+| `twitter.player`                   | string                  | Url for the video to play in the card. Only used with the `player` type card.                                                                                                                                                                                                                                                                        |
+| `twitter.playerWidth`              | number                  | Width of the player that plays the content on twitter (in Pixels). Only used with the `player` type card.                                                                                                                                                                                                                                            |
+| `twitter.playerHeight`             | number                  | Height of the player that plays the content on twtter (in Pixels). ONly used with the `player` type card.                                                                                                                                                                                                                                            |
 | `jsonLd`                           | object                  | Data in `ld+json` format. [See Examples](#json-dl-example).                                                                                                                                                                                                                                                                                          |
 
 ### Open Graph
@@ -97,13 +99,10 @@ Svelte SEO currently supports:
 
 ```svelte
 <script>
-  import SvelteSeo from "svelte-seo";
 </script>
 
 <SvelteSeo
-  openGraph={{
-    title: 'Open Graph Title',
-    description: 'Open Graph Description',
+  openGraph={  description: 'Open Graph Description',
     url: 'https://www.example.com/page',
     type: 'website',
     images: [
@@ -115,19 +114,17 @@ Svelte SEO currently supports:
       }
      ]
   }}
-/>
+/>} />
 ```
 
 #### Article Example
 
 ```svelte
 <script>
-  import SvelteSeo from "svelte-seo";
 </script>
 
 <SvelteSeo
-  openGraph={{
-    title: "Open Graph Article Title",
+  openGraph={tle",
     description: "Description of open graph article",
     type: "article",
     url: "https://www.example.com/articles/article-title",
@@ -151,7 +148,7 @@ Svelte SEO currently supports:
       },
     ],
   }}
-/>
+/>} />
 ```
 
 ### Twitter Link Preview Card
@@ -162,18 +159,15 @@ Allows Twitter Link Preview Cards (otherwise known as a Summary Card with Large 
 
 ```svelte
 <script>
-  import SvelteSeo from "svelte-seo";
 </script>
 
 <SvelteSeo
-  twitter={{
-    site: "@username",
-    title: "Twitter Card Title",
+  twitter={ "Twitter Card Title",
     description: "Description of Twitter Card",
     image: "https://www.example.com/images/cover.jpg",
     imageAlt: "Alt text for the card!",
   }}
-/>
+/>} />
 ```
 
 ### JSON-LD
@@ -186,13 +180,10 @@ To discover all the different content types JSON-LD offers check out: https://de
 
 ```svelte
 <script>
-  import SvelteSeo from "svelte-seo";
 </script>
 
 <SvelteSeo
-  jsonLd={{
-    '@type': 'Article',
-    mainEntityOfPage: {
+  jsonLd={ntityOfPage: {
       '@type': 'WebPage',
       '@id': 'https://example.com/article'
     },
@@ -217,7 +208,7 @@ To discover all the different content types JSON-LD offers check out: https://de
       }
     }
   }}
-/>
+/>} />
 ```
 
 ## Acknowledgements

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,5 +1,0 @@
-{
-  "name": "Using fixtures to represent data",
-  "email": "hello@cypress.io",
-  "body": "Fixtures are a great way to mock data for responses to routes"
-}

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -180,6 +180,102 @@ describe("SEO Meta", () => {
     );
   });
 
+  it("renders Twitter Card tags for summary type card", () => {
+    cy.visit("/summary");
+    cy.get('head meta[name="twitter:card"]').should(
+      "have.attr",
+      "content",
+      "summary"
+    );
+
+    cy.get('head meta[name="twitter:site"]').should(
+      "have.attr",
+      "content",
+      "@username"
+    );
+
+    cy.get('head meta[name="twitter:title"]').should(
+      "have.attr",
+      "content",
+      "Twitter Card Title"
+    );
+
+    cy.get('head meta[name="twitter:description"]').should(
+      "have.attr",
+      "content",
+      "Description of Twitter Card"
+    );
+
+    cy.get('head meta[name="twitter:image"]').should(
+      "have.attr",
+      "content",
+      "https://www.example.com/images/cover.jpg"
+    );
+
+    cy.get('head meta[name="twitter:image:alt"]').should(
+      "have.attr",
+      "content",
+      "Alt text for the card!"
+    );
+  });
+
+  it("renders Twitter Card tags for player type card", () => {
+    cy.visit("/player");
+    cy.get('head meta[name="twitter:card"]').should(
+      "have.attr",
+      "content",
+      "player"
+    );
+
+    cy.get('head meta[name="twitter:site"]').should(
+      "have.attr",
+      "content",
+      "@username"
+    );
+
+    cy.get('head meta[name="twitter:title"]').should(
+      "have.attr",
+      "content",
+      "Twitter Card Title"
+    );
+
+    cy.get('head meta[name="twitter:description"]').should(
+      "have.attr",
+      "content",
+      "Description of Twitter Card"
+    );
+
+    cy.get('head meta[name="twitter:image"]').should(
+      "have.attr",
+      "content",
+      "https://www.example.com/images/cover.jpg"
+    );
+
+    cy.get('head meta[name="twitter:image:alt"]').should(
+      "have.attr",
+      "content",
+      "Alt text for the card!"
+    );
+
+    cy.get('head meta[name="twitter:player"]').should(
+      "have.attr",
+      "content",
+      "https://www.example.com/videos/example-video"
+    );
+
+    cy.get('head meta[name="twitter:player:width"]').should(
+      "have.attr",
+      "content",
+      "200"
+    );
+
+    cy.get('head meta[name="twitter:player:height"]').should(
+      "have.attr",
+      "content",
+      "100"
+    );
+  });
+
   it("renders child elements of SvelteSEO", () => {
     cy.get('head link[rel="manifest"]').should(
       "have.attr",

--- a/dev/components/App.svelte
+++ b/dev/components/App.svelte
@@ -1,7 +1,6 @@
 <script>
   import SvelteSeo from "../../src/SvelteSeo.svelte";
 
-
   const openGraph = {
     title: "Open Graph Article Title",
     description: "Description of open graph article",
@@ -34,12 +33,21 @@
     ],
   };
 
-  const twitter = {
-    site: "@username",
-    title: "Twitter Card Title",
-    description: "Description of Twitter Card",
-    image: "https://www.example.com/images/cover.jpg",
-    imageAlt: "Alt text for the card!",
+  const twitter = () => {
+    const playerPath = "/player" === window.location.pathname;
+    const summaryPath = "/summary" === window.location.pathname;
+    console.log((playerPath && 100) || undefined);
+    return {
+      card: (playerPath && "player") || (summaryPath && "summary") || undefined,
+      site: "@username",
+      title: "Twitter Card Title",
+      description: "Description of Twitter Card",
+      image: "https://www.example.com/images/cover.jpg",
+      imageAlt: "Alt text for the card!",
+      player: "https://www.example.com/videos/example-video",
+      playerWidth: (playerPath && 200) || undefined,
+      playerHeight: (playerPath && 100) || undefined,
+    };
   };
 
   const jsonLd = {
@@ -53,6 +61,7 @@
     datePublished: "2020-08-03T17:31:37Z",
     dateModified: "2020-08-20T09:31:37Z",
   };
+
 </script>
 
 <SvelteSeo
@@ -61,7 +70,7 @@
   keywords="Keywords of article page"
   canonical="https://www.example.com"
   {openGraph}
-  {twitter}
+  twitter={twitter()}
   {jsonLd}
 >
   <link rel="manifest" href="/manifest.json" />

--- a/dev/components/App.svelte
+++ b/dev/components/App.svelte
@@ -36,7 +36,6 @@
   const twitter = () => {
     const playerPath = "/player" === window.location.pathname;
     const summaryPath = "/summary" === window.location.pathname;
-    console.log((playerPath && 100) || undefined);
     return {
       card: (playerPath && "player") || (summaryPath && "summary") || undefined,
       site: "@username",

--- a/rollup.config.dev.js
+++ b/rollup.config.dev.js
@@ -17,7 +17,7 @@ function serve() {
       if (server) return;
       server = require("child_process").spawn(
         "npm",
-        ["run", "start", "--", "--dev"],
+        ["run", "start", "--", "--dev", "--single"],
         {
           stdio: ["ignore", "inherit", "inherit"],
           shell: true,

--- a/src/SvelteSeo.svelte
+++ b/src/SvelteSeo.svelte
@@ -104,7 +104,7 @@
   {/if}
 
   {#if twitter}
-    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:card" content={twitter.card || "summary_large_image" }/>
     {#if twitter.site}
       <meta
         name="twitter:site"
@@ -129,10 +129,28 @@
         content={twitter.image}
       />
     {/if}
-    {#if twitter.imageAlt}
+     {#if twitter.imageAlt}
       <meta
         name="twitter:image:alt"
         content={twitter.imageAlt}
+      />
+    {/if}
+    {#if twitter.player}
+      <meta
+        name="twitter:player"
+        content={twitter.player}
+      />
+    {/if}
+     {#if twitter.playerWidth}
+      <meta
+        name="twitter:player:width"
+        content={twitter.playerWidth}
+      />
+    {/if}
+    {#if twitter.playerHeight}
+      <meta
+        name="twitter:player:height"
+        content={twitter.playerHeight}
       />
     {/if}
   {/if}

--- a/types/SvelteSeo.d.ts
+++ b/types/SvelteSeo.d.ts
@@ -47,12 +47,18 @@ export interface OpenGraphImage {
 }
 
 export interface Twitter {
+  card?: TwitterCard;
   site?: string;
   title?: string;
   description?: string;
   image?: string;
   imageAlt?: string;
+  player?: string;
+  playerWidth?: number;
+  playerHeight?: number;
 }
+
+export type TwitterCard = 'summary' | 'summary_large_image' | 'player'
 
 export default class SvelteSeo extends SvelteComponentTyped<
   SvelteSeoProps,


### PR DESCRIPTION
@artiebits
Recommended new version `1.3.2`
Added:
 - twitter card input to select between the following card types as defined on [twitter documentation](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/abouts-cards):
   - summary
   - summary_large_image
   - player
 - twitter parameters for player url, player width and player height as defined on [twitter player card docs](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/player-card)
 - Cypress tests to validate both default (summary_large_image), summary and player card types

Typed and  Tested
