### PR TITLE
Fix languageAlternates index to ensure it is unique

### DIFF
--- a/src/lib/index.svelte
+++ b/src/lib/index.svelte
@@ -58,7 +58,7 @@
   {/if}
 
   {#if languageAlternates}
-    {#each languageAlternates as { href, hreflang } (href)}
+    {#each languageAlternates as { href, hreflang } (hreflang)}
       <link rel="alternate" {href} {hreflang} />
     {/each}
   {/if}


### PR DESCRIPTION
This ensure we can use same url for `en`, `en-US` or `x-default`.