### PR TITLE
Add Svelte v5 as peer dep to fix missing props type declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svelte-seo",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "svelte-seo",
-      "version": "1.6.1",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "schema-dts": "^1.1.5"
@@ -31,6 +31,9 @@
         "tslib": "^2.8.1",
         "typescript": "^5.9.2",
         "vite": "^7.1.7"
+      },
+      "peerDependencies": {
+        "svelte": "5"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "typescript": "^5.9.2",
     "vite": "^7.1.7"
   },
+  "peerDependencies": {
+    "svelte": "5"
+  },
   "type": "module",
   "keywords": [
     "svelte",


### PR DESCRIPTION
This fixes #108 which I also ran into when updating to v1.7.0

As PR #101 introduced Svelte v5 runes as well as types it must be included as a peer dependency to the package in order to get proper type generation during packaging. Please note that this change is a breaking change and needs a semver bump accordingly as all Svelte 3 and 4 users cannot use this new version.

Also note that v1.7.0 is a breaking change instead of a feature bump due to using Svelte v5 runes in the distributed code. Updating to v1.7.0 should break every Svelte v3 and v4 projects which in turn violates semver.