### PR TITLE
fix: emit og:image instead of og:image:url for images array

### DIFF
--- a/src/lib/open-graph.svelte
+++ b/src/lib/open-graph.svelte
@@ -26,7 +26,8 @@
       {#each value as image (image)}
         {#each Object.entries(image) as [imgKey, imgValue] (imgKey)}
           {#if imgValue !== null && imgValue !== undefined}
-            <meta property="og:image:{imgKey}" content={imgValue.toString()} />
+            {@const prop = imgKey === "url" ? "og:image" : `og:image:${imgKey}`}
+            <meta property={prop} content={imgValue.toString()} />
           {/if}
         {/each}
       {/each}

--- a/src/tests/open-graph.test.js
+++ b/src/tests/open-graph.test.js
@@ -27,8 +27,8 @@ test.describe("Testing OpenGraph meta tags", async () => {
     );
   });
 
-  test("Loads og:image:url tag correctly", async ({ page }) => {
-    const element = page.locator("meta[property='og:image:url']");
+  test("Loads og:image tag correctly", async ({ page }) => {
+    const element = page.locator("meta[property='og:image']");
     expect(element, "The tag must exist").toBeDefined();
     expect(await element.count(), "Loads the right amount of tags").toBe(2);
   });


### PR DESCRIPTION
## Problem

The `images` handler in `open-graph.svelte` emits `og:image:url` instead of bare `og:image` for the `url` key. Without the root `og:image` tag, most social platforms (Facebook, LinkedIn, Twitter/X, Discord, Slack) do not pick up the image.

The `videos` handler already correctly special-cases `url` to emit `og:video`, but the `images` handler was missing this same logic — a copy-paste inconsistency.

## Fix

Mirror the `videos` pattern: when `imgKey === "url"`, emit `og:image` instead of `og:image:url`.

```svelte
{@const prop = imgKey === "url" ? "og:image" : \`og:image:\${imgKey}\`}
```

One line changed.

## References

- OG spec on structured properties: https://ogp.me/#structured
- The spec's own examples always use bare `og:image`, not `og:image:url` alone
- `og:image` is listed as one of the four required basic metadata properties

## Tests

Updated the existing test to assert `og:image` instead of `og:image:url`. All 81 tests pass.